### PR TITLE
using popen3's own escaping instead of Shellwords for the filenames

### DIFF
--- a/lib/multi_exiftool/executable.rb
+++ b/lib/multi_exiftool/executable.rb
@@ -1,6 +1,5 @@
 # coding: utf-8
 require 'open3'
-require 'shellwords'
 
 module MultiExiftool
 
@@ -36,15 +35,6 @@ module MultiExiftool
 
     private
 
-    def escape str
-      Shellwords.escape(str.to_s)
-    end
-
-    def escaped_filenames
-      raise MultiExiftool::Error.new('No filenames.') if filenames.empty?
-      filenames.map { |fn| Shellwords.escape(fn) }
-    end
-
     def options_args
       opts = options
       return [] if opts.empty?
@@ -63,7 +53,7 @@ module MultiExiftool
     end
 
     def execute_command
-      stdin, @stdout, @stderr = Open3.popen3(command)
+      stdin, @stdout, @stderr = Open3.popen3(*command)
     end
 
   end

--- a/lib/multi_exiftool/reader.rb
+++ b/lib/multi_exiftool/reader.rb
@@ -34,12 +34,13 @@ module MultiExiftool
     # maybe even for creating a batch-file with exiftool command to be
     # processed.
     def command
+      fail MultiExiftool::Error, 'No filenames.' if filenames.empty?
       cmd = [exiftool_command]
       cmd << MANDATORY_ARGS
       cmd << options_args
       cmd << tags_args
-      cmd << escaped_filenames
-      cmd.flatten.join(' ')
+      cmd << filenames
+      cmd.flatten
     end
 
     alias read execute # :nodoc:

--- a/lib/multi_exiftool/writer.rb
+++ b/lib/multi_exiftool/writer.rb
@@ -29,11 +29,12 @@ module MultiExiftool
     # maybe even for creating a batch-file with exiftool command to be
     # processed.
     def command
+      fail MultiExiftool::Error, 'No filenames.' if filenames.empty?
       cmd = [exiftool_command]
       cmd << options_args
       cmd << values_args
-      cmd << escaped_filenames
-      cmd.flatten.join(' ')
+      cmd << filenames
+      cmd.flatten
     end
 
     alias write execute # :nodoc:
@@ -51,9 +52,9 @@ module MultiExiftool
         if val.respond_to? :to_hash
           res << values_to_param_array(val.to_hash).map {|arg| "#{tag}:#{arg}"}
         elsif val.respond_to? :to_ary
-          res << val.map {|v| "#{tag}=#{escape(v)}"}
+          res << val.map {|v| "#{tag}=#{v}"}
         else
-          res << "#{tag}=#{escape(val)}"
+          res << "#{tag}=#{val}"
         end
       end
       res.flatten

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -22,12 +22,12 @@ module TestHelper
     executed = {exec: false}
     open3_eigenclass = class << Open3; self; end
     open3_eigenclass.module_exec(command, outstr, errstr, executed) do |cmd, out, err, exec|
-      define_method :popen3 do |arg|
+      define_method :popen3 do |*arg|
         exec[:exec] = true
-        if arg == cmd
+        if arg.join(' ') == cmd
           return [nil, StringIO.new(out), StringIO.new(err)]
         else
-          raise ArgumentError.new("Expected call of Open3.popen3 with argument #{cmd.inspect} but was #{arg.inspect}.")
+          raise ArgumentError.new("Expected call of Open3.popen3 with argument #{cmd.inspect} but was #{arg.join(' ').inspect}.")
         end
       end
     end

--- a/test/test_functional_api.rb
+++ b/test/test_functional_api.rb
@@ -63,7 +63,7 @@ class TestFunctionalApi < Test::Unit::TestCase
     end
 
     test 'tags with spaces in values' do
-      mocking_open3 'exiftool -author=janfri -comment=some\ comment a.jpg b.tif c.bmp', '', '' do
+      mocking_open3 'exiftool -author=janfri -comment=some comment a.jpg b.tif c.bmp', '', '' do
         values = {:author => 'janfri', :comment => 'some comment'}
         MultiExiftool.write @filenames, values
       end
@@ -77,7 +77,7 @@ class TestFunctionalApi < Test::Unit::TestCase
     end
 
     test 'tags with array-like values' do
-      mocking_open3 'exiftool -keywords=one -keywords=two -keywords=and\ three a.jpg b.tif c.bmp', '', '' do
+      mocking_open3 'exiftool -keywords=one -keywords=two -keywords=and three a.jpg b.tif c.bmp', '', '' do
         values = {keywords: ['one', 'two', 'and three']}
         MultiExiftool.write @filenames, values
       end

--- a/test/test_reader.rb
+++ b/test/test_reader.rb
@@ -11,7 +11,7 @@ class TestReader < Test::Unit::TestCase
 
     test 'simple case' do
       @reader.filenames = %w(a.jpg b.tif c.bmp)
-      command = 'exiftool -J a.jpg b.tif c.bmp'
+      command = ['exiftool', '-J', 'a.jpg', 'b.tif', 'c.bmp']
       assert_equal command, @reader.command
     end
 
@@ -27,51 +27,51 @@ class TestReader < Test::Unit::TestCase
 
     test 'one filename as string' do
       @reader.filenames = 'a.jpg'
-      command = 'exiftool -J a.jpg'
+      command = ['exiftool', '-J', 'a.jpg']
       assert_equal command, @reader.command
     end
 
     test 'filenames with spaces' do
       @reader.filenames = ['one file with spaces.jpg', 'another file with spaces.tif']
-      command = 'exiftool -J one\ file\ with\ spaces.jpg another\ file\ with\ spaces.tif'
+      command = ['exiftool', '-J', 'one file with spaces.jpg', 'another file with spaces.tif']
       assert_equal command, @reader.command
     end
 
     test 'tags' do
       @reader.filenames = %w(a.jpg b.tif c.bmp)
       @reader.tags = %w(author fnumber)
-      command = 'exiftool -J -author -fnumber a.jpg b.tif c.bmp'
+      command = ['exiftool', '-J', '-author', '-fnumber', 'a.jpg', 'b.tif', 'c.bmp']
       assert_equal command, @reader.command
     end
 
     test 'options with boolean argument' do
       @reader.filenames = %w(a.jpg b.tif c.bmp)
       @reader.options = {:e => true}
-      command = 'exiftool -J -e a.jpg b.tif c.bmp'
+      command = ['exiftool', '-J', '-e', 'a.jpg', 'b.tif', 'c.bmp']
       assert_equal command, @reader.command
     end
 
     test 'options with value argument' do
       @reader.filenames = %w(a.jpg b.tif c.bmp)
       @reader.options = {:lang => 'de'}
-      command = 'exiftool -J -lang de a.jpg b.tif c.bmp'
+      command = ['exiftool', '-J', '-lang de', 'a.jpg', 'b.tif', 'c.bmp']
       assert_equal command, @reader.command
     end
 
     test 'numerical flag' do
       @reader.filenames = %w(a.jpg b.tif c.bmp)
       @reader.numerical = true
-      command = 'exiftool -J -n a.jpg b.tif c.bmp'
+      command = ['exiftool', '-J', '-n', 'a.jpg', 'b.tif', 'c.bmp']
       assert_equal command, @reader.command
     end
 
     test 'group flag' do
       @reader.filenames = %w(a.jpg)
       @reader.group = 0
-      command = 'exiftool -J -g 0 a.jpg'
+      command = ['exiftool', '-J', '-g 0', 'a.jpg']
       assert_equal command, @reader.command
       @reader.group = 1
-      command = 'exiftool -J -g 1 a.jpg'
+      command = ['exiftool', '-J', '-g 1', 'a.jpg']
       assert_equal command, @reader.command
     end
 

--- a/test/test_writer.rb
+++ b/test/test_writer.rb
@@ -23,14 +23,14 @@ class TestWriter < Test::Unit::TestCase
     test 'one filename as string' do
       @writer.values = {:author => 'janfri'}
       @writer.filenames = 'a.jpg'
-      command = 'exiftool -author=janfri a.jpg'
+      command = ['exiftool', '-author=janfri', 'a.jpg']
       assert_equal command, @writer.command
     end
 
     test 'filenames with spaces' do
       @writer.filenames = ['one file with spaces.jpg', 'another file with spaces.tif']
       @writer.values = {:author => 'janfri'}
-      command = 'exiftool -author=janfri one\ file\ with\ spaces.jpg another\ file\ with\ spaces.tif'
+      command = ['exiftool', '-author=janfri', 'one file with spaces.jpg', 'another file with spaces.tif']
       assert_equal command, @writer.command
     end
 
@@ -44,7 +44,7 @@ class TestWriter < Test::Unit::TestCase
 
     test 'simple case' do
       @writer.values = {:author => 'janfri'}
-      command = 'exiftool -author=janfri a.jpg b.tif c.bmp'
+      command = ['exiftool', '-author=janfri', 'a.jpg', 'b.tif', 'c.bmp']
       assert_equal command, @writer.command
     end
 
@@ -60,47 +60,47 @@ class TestWriter < Test::Unit::TestCase
 
     test 'tags with spaces in values' do
       @writer.values = {:author => 'janfri', :comment => 'some comment'}
-      command = 'exiftool -author=janfri -comment=some\ comment a.jpg b.tif c.bmp'
+      command = ['exiftool', '-author=janfri', '-comment=some comment', 'a.jpg', 'b.tif', 'c.bmp']
       assert_equal command, @writer.command
     end
 
     test 'tags with rational value' do
       @writer.values ={shutterspeed: Rational(1, 125)}
-      command = 'exiftool -shutterspeed=1/125 a.jpg b.tif c.bmp'
+      command = ['exiftool', '-shutterspeed=1/125', 'a.jpg', 'b.tif', 'c.bmp']
       assert_equal command, @writer.command
     end
 
     test 'tags with array-like values' do
       @writer.values = {keywords: ['one', 'two', 'and three']}
-      command = 'exiftool -keywords=one -keywords=two -keywords=and\ three a.jpg b.tif c.bmp'
+      command = ['exiftool', '-keywords=one', '-keywords=two', '-keywords=and three', 'a.jpg', 'b.tif', 'c.bmp']
       assert_equal command, @writer.command
     end
 
     test 'options with boolean argument' do
       @writer.values = {:author => 'janfri'}
       @writer.options = {:overwrite_original => true}
-      command = 'exiftool -overwrite_original -author=janfri a.jpg b.tif c.bmp'
+      command = ['exiftool', '-overwrite_original', '-author=janfri', 'a.jpg', 'b.tif', 'c.bmp']
       assert_equal command, @writer.command
     end
 
     test 'options with value argument' do
       @writer.values = {:author => 'janfri'}
       @writer.options = {:out => 'output_file'}
-      command = 'exiftool -out output_file -author=janfri a.jpg b.tif c.bmp'
+      command = ['exiftool', '-out output_file', '-author=janfri', 'a.jpg', 'b.tif', 'c.bmp']
       assert_equal command, @writer.command
     end
 
     test 'numerical flag' do
       @writer.values = {:author => 'janfri'}
       @writer.numerical = true
-      command = 'exiftool -n -author=janfri a.jpg b.tif c.bmp'
+      command = ['exiftool', '-n', '-author=janfri', 'a.jpg', 'b.tif', 'c.bmp']
       assert_equal command, @writer.command
     end
 
     test 'overwrite_original flag' do
       @writer.values = {author: 'janfri'}
       @writer.overwrite_original = true
-      command = 'exiftool -overwrite_original -author=janfri a.jpg b.tif c.bmp'
+      command = ['exiftool', '-overwrite_original', '-author=janfri', 'a.jpg', 'b.tif', 'c.bmp']
       assert_equal command, @writer.command
     end
 

--- a/test/test_writer_groups.rb
+++ b/test/test_writer_groups.rb
@@ -11,7 +11,7 @@ class TestWriterGroups < Test::Unit::TestCase
 
   test 'simple case' do
     @writer.values = {:exif => {:comment => 'test'}  }
-    command = 'exiftool -exif:comment=test a.jpg b.bmp c.tif'
+    command = ['exiftool', '-exif:comment=test', 'a.jpg', 'b.bmp', 'c.tif']
     assert_equal command, @writer.command
   end
 
@@ -24,7 +24,7 @@ class TestWriterGroups < Test::Unit::TestCase
         author: janfri
         subjectlocation: somewhere else
     END
-    command = 'exiftool -exif:author=janfri -exif:comment=some\ comment -xmp:author=janfri -xmp:subjectlocation=somewhere\ else a.jpg b.bmp c.tif'
+    command = ['exiftool', '-exif:author=janfri', '-exif:comment=some comment', '-xmp:author=janfri', '-xmp:subjectlocation=somewhere else', 'a.jpg', 'b.bmp', 'c.tif']
     assert_equal command, @writer.command
   end
 
@@ -36,7 +36,7 @@ class TestWriterGroups < Test::Unit::TestCase
           - two
           - and three
     END
-    command = 'exiftool -exif:keywords=one -exif:keywords=two -exif:keywords=and\ three a.jpg b.bmp c.tif'
+    command = ['exiftool', '-exif:keywords=one', '-exif:keywords=two', '-exif:keywords=and three', 'a.jpg', 'b.bmp', 'c.tif']
     assert_equal command, @writer.command
   end
 


### PR DESCRIPTION
As discussed in Issue #1, I replaced the shellword-escaping with Popen3's (well, actually `Kernel.spawn`'s) automatic escaping. This includes passing tests.
