### PR TITLE
Remove use of keyword args in .delete_values to restore ruby 1.9 support

### DIFF
--- a/lib/multi_exiftool.rb
+++ b/lib/multi_exiftool.rb
@@ -60,7 +60,8 @@ module MultiExiftool
     #   unless errors.empty?
     #     # do error handling
     #   end
-    def delete_values filenames, tags: :all
+    def delete_values filenames, opts={}
+      tags = opts.fetch(:tags, :all)
       values = Array(tags).inject(Hash.new) {|h,tag| h[tag] = nil; h}
       write(filenames, values)
     end


### PR DESCRIPTION
Closes #11 